### PR TITLE
fix(ci): isolate Fly API tokens per environment

### DIFF
--- a/.github/workflows/fly-prod.yml
+++ b/.github/workflows/fly-prod.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only -a myfute-api
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}

--- a/.github/workflows/fly-staging.yml
+++ b/.github/workflows/fly-staging.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Deploy to Fly (Staging)
         run: flyctl deploy --remote-only -c fly.staging.toml
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}


### PR DESCRIPTION
## Context
Isolate Fly.io deploy tokens per environment to prevent cross-environment authorization failures.

## Changes
- Introduced FLY_API_TOKEN_PROD secret usage in production workflow
- Introduced FLY_API_TOKEN_STAGING secret usage in staging workflow
- Removed shared token dependency

## Rationale
Ensures proper environment isolation and reduces security risk by limiting token scope.

## Impact
No application changes.
CI/CD configuration improvement only.